### PR TITLE
Release v0.2.1: Export Operator to support programmatic query construction (fixes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 N/A
 
+## [0.2.1] - 2024-12-16
+
+### Added
+
+- `Operator` is now part of the public API
+
 ## [0.2.0] - 2024-08-03
 
 ### Added
@@ -33,6 +39,7 @@ N/A
 - Support for user-provided MatchSpy and MatchDecider implementations
 - Support for arbitrary types in Xapian document slots
 
-[unreleased]: https://github.com/torrancew/xapian-rs/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/torrancew/xapian-rs/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/torrancew/xapian-rs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/torrancew/xapian-rs/compare/tag/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/torrancew/xapian-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xapian-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "autocxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xapian-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Rust bindings for the Xapian search engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub(crate) mod ffi;
 mod iter;
 
 mod query;
-pub use query::{FieldProcessor, Query, QueryParser};
+pub use query::{FieldProcessor, Operator, Query, QueryParser};
 
 mod search;
 pub use search::{

--- a/src/query.rs
+++ b/src/query.rs
@@ -43,27 +43,56 @@ impl<T: FieldProcessor + 'static> From<T> for FieldProcessorWrapper {
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(PartialEq)]
+/// An [`Operator`] can be used to compose queries in novel ways
+///
+/// See [upstream docs][upstream] for details such as implications on document weighting, etc
+///
+/// [upstream]: https://xapian.org/docs/apidoc/html/classXapian_1_1Query.html#a7e7b6b8ad0c915c2364578dfaaf6100b
 pub enum Operator {
+    /// Only matches documents which match all subqueries
     And = 0,
+    /// Matches documents which match at least one subquery
     Or,
+    /// Matches documents which matches only the first subquery
     AndNot,
+    /// Matches documents which match an odd number of subqueries
     XOr,
+    /// Matches documents which match the first subquery, and takes extra weight from the remaining
+    /// subqueries
     AndMaybe,
+    /// Similar to [`And`], but weight is only taken from the first subquery (often used with
+    /// boolean terms)
     Filter,
+    /// Matches documents where all subqueries match and are near one another
     Near,
+    /// Matches documents where subqueries match, are near one another and in order
     Phrase,
+    /// Matches documents with a value slot in the given range
     ValueRange,
+    /// Scales the weight contributed by a subquery
     ScaleWeight,
+    /// Picks the best N subqueries, and combines them with an [`Or`]
     EliteSet,
+    /// Matches documents with a value slot greater than or equal to the given value
     ValueGe,
+    /// Matches documents with a value slot less than or equal to the given value
     ValueLe,
+    /// Matches documents which match any of the subqueries, but weights them as if they were a
+    /// single term
     Synonym,
+    /// Sets the maximum weight of any subquery
     Max,
+    /// Enables wildcard expansion on subqueries
     Wildcard,
+    /// Represents an invalid query
     Invalid = 99,
+    #[doc(hidden)]
     LeafTerm = 100,
+    #[doc(hidden)]
     LeafPostingSource,
+    #[doc(hidden)]
     LeafMatchAll,
+    #[doc(hidden)]
     LeafMatchNothing,
 }
 


### PR DESCRIPTION
Exports `Operator` so that the various combinators on `Query` can be used by consumers of the crate